### PR TITLE
Fix cairo context memory leak

### DIFF
--- a/gdk/Gdk.metadata
+++ b/gdk/Gdk.metadata
@@ -12,6 +12,7 @@
   <attr path="/api/namespace/boxed[@cname='GdkPixbufFormat']/method[@name='GetMimeTypes']/return-type" name="null_term_array">1</attr> 
   <attr path="/api/namespace/callback[@cname='GdkPixbufDestroyNotify']/*/*[@type='guchar*']" name="array">1</attr>
   <attr path="/api/namespace/class[@cname='GdkCairo_']" name="name">CairoHelper</attr>
+  <attr path="/api/namespace/class[@cname='GdkCairo_']/method[@name='Create']/return-type" name="owned">true</attr>
   <attr path="/api/namespace/class[@cname='GdkDrag_']/method[@name='Begin']" name="hidden">1</attr>
   <attr path="/api/namespace/class[@cname='GdkDrag_']/method[@name='FindWindowForScreen']/*/*[@name='dest_window']" name="pass_as">out</attr>
   <attr path="/api/namespace/class[@cname='GdkEvent_']/method[@name='HandlerSet']" name="hidden">1</attr>


### PR DESCRIPTION
CairoHelper.Create would pass "owner=false" to the ctor of Cairo.Context, which would then wrongfully increment its reference counter. Thus making it impossible to free the context or any resource it is holding with Dispose().

This adds the metadata attribute to correctly generate CairoHelper.Create with "owner=true".

Test: Make a new Gtk#3.0 app and add this to the constructor of your window.

```
Maximize ();
Drawn += (o, args) => Gdk.CairoHelper.Create ((o as Window).Window).Dispose ();
System.Threading.Tasks.Task.Run (() => { 
    while (true) { 
        System.Threading.Thread.Sleep (100);
        Gtk.Application.Invoke ((sender, e) => QueueDraw ());
    }
});
```
